### PR TITLE
refactor util functions; update tests; bump version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,6 @@ setup(description=__doc__.splitlines()[0],
       setup_requires=setup_requires,
       install_requires=requirements,
       package_dir={'tdtax': 'tdtax'},
-      package_data={'tdtax': ['viz_template.html']}
+      package_data={'tdtax': ['viz_template.html']},
       url='https://github.com/profjsb/timedomain-taxonomy'
       )

--- a/tdtax/__init__.py
+++ b/tdtax/__init__.py
@@ -7,87 +7,29 @@ and is validated against the schema file `tdtax/schema.json`
 import os
 from os.path import join as pjoin
 import json
-import pkgutil
-import datetime
 
 import yaml
 from yaml import Loader
 from jsonschema import validate
 
+from .util import write_viz, merge_yamls
 
 _basedir = os.path.dirname(__file__)
 schema = json.load(open(pjoin(_basedir, "schema.json"), "r"))
 
-
-def write_viz(vega_taxonomy, outname="viz.html"):
-    """
-    Use the current taxonomy to vizualize the tree
-    with d3.
-
-    >> import tdtax
-    >> tdtax.write_viz(tdtax.vega_taxonomy)
-
-    """
-    text = pkgutil.get_data(__name__, "viz_template.html").decode()
-    text = text.replace("%%JSON%%", json.dumps(vega_taxonomy))
-    text = text.replace("%%VERSION%%", __version__)
-    text = text.replace("%%DATE%%", str(datetime.datetime.utcnow()))
-    f = open(outname, "w")
-    f.write(text)
-    f.close()
-    print(f"wrote {outname}")
-
-
-def walk_and_replace(d, path="./", verbose=False):
-    """
-    recursively replace references to YAMLs
-    """
-    if not isinstance(d, dict):
-        return
-
-    for key, value in d.items():
-        if isinstance(value, dict):
-            walk_and_replace(value, path=path, verbose=verbose)
-        elif isinstance(value, list):
-            for i in range(len(value)):
-                if isinstance(value[i], dict):
-                    if value[i].get("ref") is not None:
-                        ref = path + value[i].get("ref")
-                        if os.path.exists(ref):
-                            replacement = yaml.load(open(ref), Loader=Loader)
-                            value[i] = replacement
-                        else:
-                            if verbose:
-                                print(
-                                    f"Did not find file {ref}."
-                                    "Adding placeholder."
-                                     )
-                            basename = os.path.basename(ref).split(".")[0]
-                            value[i] = {"class": basename + "-placeholder"}
-                    walk_and_replace(value[i], path=path, verbose=verbose)
-
-
-def merge_yamls(fname):
-    taxonomy = yaml.load(open(fname), Loader=Loader)
-    path = os.path.dirname(fname) + "/"
-    walk_and_replace(taxonomy, path)
-    return taxonomy
-
-
-# get the taxonomy and validate
+# get the taxonomy and validate - raise an error if this does
+# not validate against the schema
 taxonomy = merge_yamls(pjoin(_basedir, "top.yaml"))
 validate(instance=taxonomy, schema=schema)
 
 # get a version of the taxonomy suitable for vega/d3 viz
 taxstr = json.dumps(taxonomy)
 taxstr = taxstr.replace('"class":', '"name":') \
-           .replace('"subclasses":', '"children":')
+               .replace('"subclasses":', '"children":')
 vega_taxonomy = json.loads(taxstr)
 
+__version__ = '0.0.4'
 
-__all__ = ["taxonomy", "schema", "merge_yamls", "vega_taxonomy", "write_viz"]
+__all__ = ["taxonomy", "schema", "vega_taxonomy", "write_viz", "__version__"]
 
-__version__ = '0.0.2'
-
-del (taxstr, walk_and_replace, merge_yamls,
-     os, json, pkgutil, datetime, yaml, Loader, pjoin)
+del (taxstr, merge_yamls, os, json, yaml, Loader, pjoin)

--- a/tdtax/test/test_validate.py
+++ b/tdtax/test/test_validate.py
@@ -1,5 +1,12 @@
-import tdtax
+from tdtax import schema
+from tdtax.validate import is_valid
 
 
-def test():
-    tdtax.validate(tdtax.taxonomy, tdtax.taxonomy)
+def test_validate_bad_yaml():
+    ret = is_valid("tdtax/test/bad.yaml", schema)
+    assert ret.find("not against") != -1
+
+
+def test_validate_top_yaml():
+    ret = is_valid("tdtax/top.yaml", schema)
+    assert ret.find("valid") != -1

--- a/tdtax/util.py
+++ b/tdtax/util.py
@@ -1,0 +1,69 @@
+import os
+import json
+import pkgutil
+import datetime
+import ast
+
+import yaml
+from yaml import Loader
+
+# Get version without importing module
+mod = ast.parse(pkgutil.get_data(__name__, "__init__.py").decode())
+assignments = [node for node in mod.body if isinstance(node, ast.Assign)]
+__version__ = [node.value.s for node in assignments
+               if node.targets[0].id == '__version__'][0]
+
+
+def write_viz(vega_taxonomy, outname="viz.html"):
+    """
+    Use the current taxonomy to vizualize the tree
+    with d3.
+
+    >> import tdtax
+    >> tdtax.write_viz(tdtax.vega_taxonomy)
+
+    """
+    text = pkgutil.get_data(__name__, "viz_template.html").decode()
+    text = text.replace("%%JSON%%", json.dumps(vega_taxonomy))
+    text = text.replace("%%VERSION%%", __version__)
+    text = text.replace("%%DATE%%", str(datetime.datetime.utcnow()))
+    f = open(outname, "w")
+    f.write(text)
+    f.close()
+    print(f"wrote {outname}")
+
+
+def walk_and_replace(d, path="./", verbose=False):
+    """
+    recursively replace references to YAMLs
+    """
+    if not isinstance(d, dict):
+        return
+
+    for key, value in d.items():
+        if isinstance(value, dict):
+            walk_and_replace(value, path=path, verbose=verbose)
+        elif isinstance(value, list):
+            for i in range(len(value)):
+                if isinstance(value[i], dict):
+                    if value[i].get("ref") is not None:
+                        ref = path + value[i].get("ref")
+                        if os.path.exists(ref):
+                            replacement = yaml.load(open(ref), Loader=Loader)
+                            value[i] = replacement
+                        else:
+                            if verbose:
+                                print(
+                                    f"Did not find file {ref}."
+                                    "Adding placeholder."
+                                     )
+                            basename = os.path.basename(ref).split(".")[0]
+                            value[i] = {"class": basename + "-placeholder"}
+                    walk_and_replace(value[i], path=path, verbose=verbose)
+
+
+def merge_yamls(fname):
+    taxonomy = yaml.load(open(fname), Loader=Loader)
+    path = os.path.dirname(fname) + "/"
+    walk_and_replace(taxonomy, path)
+    return taxonomy


### PR DESCRIPTION
This PR:

   - refactors helped functions to `util.py` which fixes the problem when we `del` some of the imported modules in `__init__.py` which rendered the helper functions unusable
   - updates the testing of the `validate.py` code
   - bumps the version number to 0.0.4