### PR TITLE
de-bump py.test to 4.3.1 to be compatible with skyportal

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 jsonschema
 pyyaml
 pytest-factoryboy>=2.0.3
-pytest>=5.4.3
+pytest>=4.3.1


### PR DESCRIPTION
Currently `skyportal` raises the following on `make run`: 

    [✗] Verifying Python package dependencies
    pytest 4.3.1 is installed but pytest>=5.4.3 is required by {'tdtax'}

5.4.3 does not seem to actually be required by `tdtax` so this PR de-bumps it to 4.3.1 for skyportal compatibility 

