### PR TITLE
Add phenomenological branch

### DIFF
--- a/tdtax/phenomenological.yaml
+++ b/tdtax/phenomenological.yaml
@@ -6,7 +6,8 @@ subclasses:
   - class: periodic
     subclasses:
       - class: sinusoidal
-        subclasses: ellipsoidal
+        subclasses:
+          - class: ellipsoidal
       - class: sawtooth
   - class: multi periodic
   - class: long timescale

--- a/tdtax/phenomenological.yaml
+++ b/tdtax/phenomenological.yaml
@@ -6,6 +6,7 @@ subclasses:
   - class: periodic
     subclasses:
       - class: sinusoidal
+        subclasses: ellipsoidal
       - class: sawtooth
   - class: multi periodic
   - class: long timescale

--- a/tdtax/phenomenological.yaml
+++ b/tdtax/phenomenological.yaml
@@ -29,6 +29,3 @@ subclasses:
     subclasses:
       - class: half period
       - class: double period
-  - class: nice
-    subclasses:
-      - class: niice

--- a/tdtax/phenomenological.yaml
+++ b/tdtax/phenomenological.yaml
@@ -1,0 +1,32 @@
+class: Phenomenological
+tags: [Time series characteristics]
+subclasses:
+  - class: non-variable
+  - class: variable
+  - class: periodic
+    subclasses:
+      - class: sinusoidal
+      - class: sawtooth
+  - class: multi periodic
+  - class: long timescale
+  - class: irregular
+  - class: eclipsing
+    subclasses:
+      - class: EA
+      - class: EB
+      - class: EW
+  - class: flaring
+  - class: dipping
+  - class: bogus
+    subclasses:
+      - class: galaxy
+      - class: blend
+      - class: bright star
+      - class: ccd artifact
+  - class: wrong period
+    subclasses:
+      - class: half period
+      - class: double period
+  - class: nice
+    subclasses:
+      - class: niice

--- a/tdtax/top.yaml
+++ b/tdtax/top.yaml
@@ -1,22 +1,24 @@
 class: Time-domain Source
 subclasses:
-  - ref: nonstellar.yaml
-    comments: |
-      Link to Non-stellar variability sources such as AGN
-  - class: Stellar variable
+  - class: Ontological
+    tags: [Intrinsic source properties]
     subclasses:
-      - ref: cataclysmic.yaml
-      - ref: eclipsing.yaml
-      - ref: rotating.yaml
-      - ref: eruptive.yaml
-      - ref: pulsating.yaml
-      - class: microlensing
-        tags: [stellar lensing, gravitational lensing]
+      - ref: nonstellar.yaml
+        comments: |
+          Link to Non-stellar variability sources such as AGN
+      - class: Stellar variable
         subclasses:
-          - class: binary lens
-            subclass:
-              - class: lens with planet
-          - class: triple-system lens
-          - class: binary source
-
-
+          - ref: cataclysmic.yaml
+          - ref: eclipsing.yaml
+          - ref: rotating.yaml
+          - ref: eruptive.yaml
+          - ref: pulsating.yaml
+          - class: microlensing
+            tags: [stellar lensing, gravitational lensing]
+            subclasses:
+              - class: binary lens
+                subclass:
+                  - class: lens with planet
+              - class: triple-system lens
+              - class: binary source
+  - ref: phenomenological.yaml


### PR DESCRIPTION
This PR adds a new Phenomenological class to the taxonomy. The previous version's Stellar variable/nonstellar taxonomy is contained within a newly-defined Ontological class. Both new categories are connected to the top-level Time-domain source node. Making this change will enable sources uploaded to fritz.science to be classified according to the phenomenological labels used by the ZTF Source Classification Project.