### PR TITLE
Stellar variable label updates

### DIFF
--- a/tdtax/__init__.py
+++ b/tdtax/__init__.py
@@ -28,7 +28,7 @@ taxstr = taxstr.replace('"class":', '"name":') \
                .replace('"subclasses":', '"children":')
 vega_taxonomy = json.loads(taxstr)
 
-__version__ = '0.1.4'
+__version__ = '0.1.5'
 
 __all__ = ["taxonomy", "schema", "vega_taxonomy", "write_viz", "__version__"]
 

--- a/tdtax/eclipsing.yaml
+++ b/tdtax/eclipsing.yaml
@@ -1,5 +1,5 @@
 class: Eclipsing
-subclasses: 
+subclasses:
   - class: Beta Lyrae
     tags: [types A/B, ellipsoidal, giant/supergiant, accretion disk]
     other names: [EB, B Lyr]
@@ -25,6 +25,23 @@ subclasses:
   - class: Algol
     tags: [main sequence star, less massive companion, semidetached]
     other names: [EA, Algol-type, Beta Persei-type, Beta Per]
-  - class: Symbiotic Var 
+    subclasses:
+      - class: detached MS-MS
+      - class: HW Vir
+        tags: [sdB + dM]
+        other names: [HW Virginis]
+  - class: Symbiotic Var
     tags: [cataclysmic]
     other names: [Symbiotic Variable, ZAND]
+  - class: Compact Binary
+    tags: [Has WD, NS, or BH component]
+    subclasses:
+      - class: DWD
+        tags: [double white dwarf]
+        other names: [dWD]
+      - class: NN Ser
+        tags: [WD + dM]
+        other names: [NN Serpentis]
+      - class: Redback Pulsar
+        tags: [NS + non-degenerate companion]
+        other names: [Redback]

--- a/tdtax/eruptive.yaml
+++ b/tdtax/eruptive.yaml
@@ -18,24 +18,6 @@ subclasses:
         other names: []
       - class: Shell
         other names: []
-  - class: FU Ori
-    tags: [pre-main sequence, accretion disk, T Tauri evolution, possible Orion subtype]
-    other names: [FU, FUor, FU Ori, FU Orionis]
-  - class: Orion
-    tags: [pre-main sequence, diffuse nebulae]
-    other names: [IN]
-    subclasses:
-      - class: w/Abs
-        other names: [IN(YY)]
-      - class: T Tauri
-        tags: [types F/G/K/M, pre-main sequence, strong chromospheric lines, Hayashi track]
-        other names: [TTS, TT, INT, IT]
-        subclasses:
-          - class: TTc
-            other names: [Classical TTS, Classical T Tauri]
-          - class: TTw
-            tags: [Weak emission lines]
-            other names: [Weak-line TTS, Weak-line T Tauri]
   - class: R Cor Borealis
     tags: [types F/G, supergiant]
     other names: [R Coronae Borealis, RCB, R CrB, R Cor Bor]
@@ -44,9 +26,31 @@ subclasses:
          other names: [DY Persei]
          tags: [AGB, carbon-rich]
          links: ["https://en.wikipedia.org/wiki/DY_Persei_variable"]
-  - class: Herbig AE/BE
-    tags: [types A/B, pre-main sequence]
-    other names: [HAeBe]
+  - class: YSO
+    tags: [young stellar object]
+    other names: [young stellar object]
+    subclasses:
+       - class: FU Ori
+         tags: [pre-main sequence, accretion disk, T Tauri evolution, possible Orion subtype]
+         other names: [FU, FUor, FU Ori, FU Orionis]
+       - class: Orion
+         tags: [pre-main sequence, diffuse nebulae]
+         other names: [IN]
+         subclasses:
+           - class: w/Abs
+             other names: [IN(YY)]
+           - class: T Tauri
+             tags: [types F/G/K/M, pre-main sequence, strong chromospheric lines, Hayashi track]
+             other names: [TTS, TT, INT, IT]
+             subclasses:
+               - class: TTc
+                 other names: [Classical TTS, Classical T Tauri]
+               - class: TTw
+                 tags: [Weak emission lines]
+                 other names: [Weak-line TTS, Weak-line T Tauri]
+       - class: Herbig AE/BE
+         tags: [types A/B, pre-main sequence]
+         other names: [HAeBe]
   - class: FS CMa
     tags: [irregular]
     other names: [FS Canis Majoris]

--- a/tdtax/pulsating.yaml
+++ b/tdtax/pulsating.yaml
@@ -119,10 +119,10 @@ subclasses:
         subclasses:
           - class: Symmetrical
             other names: [DCEPS, Delta Cep-type Symmetrical]
-      - class: Fundamental
-        other names: [F, Fundamental mode]
-      - class: Overtone
-        other names: [O]
+          - class: Fundamental
+            other names: [F, Fundamental mode]
+          - class: Overtone
+            other names: [O]
   - class: SPB
     tags: [type B2-B9, main sequence]
     other names: [53 Persei, Slowly Pulsating B-type, Slowly Pulsating B]

--- a/tdtax/pulsating.yaml
+++ b/tdtax/pulsating.yaml
@@ -21,12 +21,41 @@ subclasses:
         other names: [RRD]
       - class: RRe
         other names: [RRE]
+      - class: Blazhko
+        other names: [RR Lyrae Blazhko, RRBlazhko]
   - class: Alpha Cygni
     tags: [types A/B, supergiant]
     other names: [Alpha Cyg, A Cyg, ACYG]
-  - class: Mira
-    tags: [red giant, long period]
-    other names: [M, Long period variable]
+  - class: LPV
+    tags: [long-period variable]
+    other names: [long-period variable, cool giant/supergiant]
+    subclasses:
+      - class: Mira
+        tags: [red giant, long period]
+        other names: [M, Long period variable]
+      - class: Semiregular
+        tags: [giant/supergiant, long period]
+        other names: [SR, SRPV, semi-regular]
+        subclasses:
+          - class: SRa/Z-Aquarii
+            other names: [SRA]
+          - class: SRb
+            other names: [SRB]
+          - class: SRc
+            other names: [SRC]
+          - class: SRd
+            other names: [SRD]
+      - class: OSARG
+        tags: [OGLE Small-Amplitude Red Giant]
+        other names: [OGLE Small-Amplitude Red Giant]
+  - class: RV Tau
+    tags: [post-AGB, possible Population II Cepheid, instability strip, long period]
+    other names: [RV Tauri, RV]
+    subclasses:
+      - class: Const Mean Mag
+        other names: [Constant mean magnitude]
+      - class: Var Mean Mag
+        other names: [Variable mean magnitude]
   - class: Pulsating WD
     other names: [Pulsating white dwarf]
     tags: [white dwarf]
@@ -66,26 +95,6 @@ subclasses:
   - class: Beta Cephei
     tags: [type B, main sequence, Z bump]
     other names: [BCep, B Cep, Beta Canis Majoris, β Cephei, BCEP]
-  - class: Semiregular
-    tags: [giant/supergiant, long period]
-    other names: [SR, SRPV, semi-regular]
-    subclasses:
-      - class: SRa/Z-Aquarii
-        other names: [SRA]
-      - class: SRb
-        other names: [SRB]
-      - class: SRc
-        other names: [SRC]
-      - class: SRd
-        other names: [SRD]
-  - class: RV Tau
-    tags: [post-AGB, possible Population II Cepheid, instability strip, long period]
-    other names: [RV Tauri, RV]
-    subclasses:
-      - class: Const Mean Mag
-        other names: [Constant mean magnitude]
-      - class: Var Mean Mag
-        other names: [Variable mean magnitude]
   - class: Population II Cepheid
     tags: []
     other names: [Population II Ceph, Type II Ceph, Type II Cepheid, Type-II Ceph, Type-II Cepheid, CW]
@@ -110,6 +119,10 @@ subclasses:
         subclasses:
           - class: Symmetrical
             other names: [DCEPS, Delta Cep-type Symmetrical]
+      - class: Fundamental
+        other names: [F, Fundamental mode]
+      - class: Overtone
+        other names: [O]
   - class: SPB
     tags: [type B2-B9, main sequence]
     other names: [53 Persei, Slowly Pulsating B-type, Slowly Pulsating B]


### PR DESCRIPTION
This PR updates the Eclipsing, Eruptive and Pulsating taxonomy branches to include all of the ZTF Source Classification Project's ontological labels. It modifies distinct files but is intended to be implemented along with #17 to facilitate the large-scale classification of ZTF data using existing algorithms.