### PR TITLE
grant write permission on PR

### DIFF
--- a/.github/workflows/test_code.yaml
+++ b/.github/workflows/test_code.yaml
@@ -8,6 +8,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/setup-python@v1
         with:


### PR DESCRIPTION
To visualize code coverage in a PR, we need write permission