### PR TITLE
WIP: Enable local tests with act

### DIFF
--- a/.github/workflows/test_code.yaml
+++ b/.github/workflows/test_code.yaml
@@ -6,23 +6,23 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 90
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python-version: "3.8"
 
       - name: Checkout branch being tested
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: true
           clean: false
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cache/pip
@@ -37,8 +37,8 @@ jobs:
         run: |
           pytest --cache-clear --cov=tdtax > pytest-coverage.txt
       - name: Upload logs
-        uses: actions/upload-artifact@v2
-        if: ${{ always() }}
+        uses: actions/upload-artifact@v3
+        if: ${{ !env.ACT }}
         with:
           name: logs
           path: pytest-coverage.txt

--- a/.github/workflows/test_pr.yaml
+++ b/.github/workflows/test_pr.yaml
@@ -5,23 +5,23 @@ on:
       - '*'
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 90
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python-version: "3.8"
 
       - name: Checkout branch being tested
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: true
           clean: false
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cache/pip
@@ -36,8 +36,8 @@ jobs:
         run: |
           pytest --cache-clear --cov=tdtax > pytest-coverage.txt
       - name: Upload logs
-        uses: actions/upload-artifact@v2
-        if: ${{ always() }}
+        uses: actions/upload-artifact@v3
+        if: ${{ !env.ACT }}
         with:
           name: logs
           path: pytest-coverage.txt


### PR DESCRIPTION
This PR shows the workflow changes that successfully run `tdtax` tests using [act](https://github.com/nektos/act/). The ubuntu and action versions are modified according to https://github.com/skyportal/skyportal/pull/3735.

After implementing these changes, the final modification to avoid an error is to run the `upload-artifact` action only if the environment is not ACT. Otherwise, an error gets raised due to the lack of environment variables (e.g. `ACTIONS_RUNTIME_TOKEN`) that are specific to GitHub Actions runners. See https://github.com/nektos/act/issues/329#issue-672023956 and https://github.com/nektos/act/issues/285#issuecomment-987550101 for more details.