### PR TITLE
SNe Id, Idn, Ie, Ien, and LRN

### DIFF
--- a/tdtax/cataclysmic.yaml
+++ b/tdtax/cataclysmic.yaml
@@ -32,6 +32,8 @@ subclasses:
     subclasses:
       - class: Classical Nova
         other names: []
+      - class: Luminous Red Nova
+        other names: [LRN]
       - class: Nova-like
         other names: []
         subclasses:

--- a/tdtax/supernovae.yaml
+++ b/tdtax/supernovae.yaml
@@ -134,3 +134,25 @@ subclasses:
   tags: [intermediate luminosity red transient]
   links:
     - https://arxiv.org/abs/1908.02323
+- class: Id
+  tags: [hydrogen poor]
+  comments: |
+    SNe with O/Ne/Mg-rich (and C/He/H-poor) outer layers
+  other names: [SN Id, SNIId]
+  links:
+    - https://arxiv.org/pdf/2409.02054
+  subclasses:
+    - class: Idn
+      tags: [interacting, narrow line]
+      other names: [SN Idn]
+- class: Ie
+  tags: [hydrogen poor]
+  comments: |
+    SNe with O/Si/S-rich (and Mg/Ne/He/H-poor) outer layers
+  other names: [SN Ie, SNIe]
+  links:
+    - https://arxiv.org/pdf/2409.02054
+  subclasses:
+    - class: Ien
+      tags: [interacting, narrow line]
+      other names: [SN Ien]

--- a/tdtax/supernovae.yaml
+++ b/tdtax/supernovae.yaml
@@ -144,7 +144,7 @@ subclasses:
   subclasses:
     - class: Idn
       tags: [interacting, narrow line]
-      other names: [SN Idn]
+      other names: [SN Idn, SNIdn]
 - class: Ie
   tags: [hydrogen poor]
   comments: |
@@ -155,4 +155,4 @@ subclasses:
   subclasses:
     - class: Ien
       tags: [interacting, narrow line]
-      other names: [SN Ien]
+      other names: [SN Ien, SNIen]

--- a/tdtax/supernovae.yaml
+++ b/tdtax/supernovae.yaml
@@ -140,7 +140,7 @@ subclasses:
     SNe with O/Ne/Mg-rich (and C/He/H-poor) outer layers
   other names: [SN Id, SNId]
   links:
-    - https://arxiv.org/pdf/2409.02054
+    - https://arxiv.org/abs/2409.02054
   subclasses:
     - class: Idn
       tags: [interacting, narrow line]

--- a/tdtax/supernovae.yaml
+++ b/tdtax/supernovae.yaml
@@ -151,7 +151,7 @@ subclasses:
     SNe with O/Si/S-rich (and Mg/Ne/He/H-poor) outer layers
   other names: [SN Ie, SNIe]
   links:
-    - https://arxiv.org/pdf/2409.02054
+    - https://arxiv.org/abs/2409.02054
   subclasses:
     - class: Ien
       tags: [interacting, narrow line]

--- a/tdtax/supernovae.yaml
+++ b/tdtax/supernovae.yaml
@@ -138,7 +138,7 @@ subclasses:
   tags: [hydrogen poor]
   comments: |
     SNe with O/Ne/Mg-rich (and C/He/H-poor) outer layers
-  other names: [SN Id, SNIId]
+  other names: [SN Id, SNId]
   links:
     - https://arxiv.org/pdf/2409.02054
   subclasses:


### PR DESCRIPTION
This PR adds:
-  a subtype of Novae: Luminous Red Nova (LRN)
- 4 new SNe subtypes: Id, Idn, Ie, Ien

This is based on user requests, that need this in the Sitewide taxonomy of SkyPortal (that reads its content from this repo's main branch).